### PR TITLE
Mobile Responsiveness of Input Players fix to remove overlap

### DIFF
--- a/src/Components/Button/Button.js
+++ b/src/Components/Button/Button.js
@@ -4,12 +4,14 @@ const Button = ({
     handleClick,
     children,
     disabled,
-    className
+    className,
+    type
 }) => (
     <button 
      onClick={ handleClick }
      disabled={ disabled ? true : null}
      className= { className }
+     type= { type }
     >{ children }</button> 
 );
 

--- a/src/Components/InputPlayer/InputPlayer.js
+++ b/src/Components/InputPlayer/InputPlayer.js
@@ -49,6 +49,7 @@ class InputPlayer extends Component {
              disabled={ name === "" ? true : false }
              handleClick={ this.handleSubmit }
              className="btn btn-add"
+             type="submit"
             >Add</Button>
         </div>
         );

--- a/src/Components/InputPlayerGroup/InputPlayerGroup.js
+++ b/src/Components/InputPlayerGroup/InputPlayerGroup.js
@@ -7,9 +7,12 @@ const InputPlayerGroup = ({ totalTeams, players, stage, handleClick }) => (
     <React.Fragment>
         { stage !== 2 ? null :
         <div className="page-container">
-            <h1 className="stage-title">Add Players</h1>
-            <InputPlayer/>
-            <PlayerList/>
+            <div className="page-content">
+                <h1>Add Players</h1>
+            
+                <InputPlayer/>
+                <PlayerList/>
+            </div>
             <Button 
                 disabled={ players.length < totalTeams ? true : false}
                 handleClick={ handleClick }
@@ -17,8 +20,7 @@ const InputPlayerGroup = ({ totalTeams, players, stage, handleClick }) => (
             >Next</Button> 
         </div>
         }
-    </React.Fragment>
-    
+    </React.Fragment>  
 );
 
 export default InputPlayerGroup

--- a/src/styling/InputPlayer.scss
+++ b/src/styling/InputPlayer.scss
@@ -1,3 +1,12 @@
+.add-players{
+    position: absolute;
+    top: 20vh;
+
+}
+
+
+
+
 .input-players{
     display:flex;
     flex-direction: column;
@@ -23,7 +32,7 @@
 }
 
 .player-table{
-    height: 200px;
+    height: 20vh;
     width: 80vw;
     @media (min-width: 37.5em) {
         width: 500px; 
@@ -34,5 +43,7 @@
     scrollbar-color: $sec-colour;
     th{
         text-align: start;
+        text-decoration: underline;
+        text-transform: uppercase;
     }
 }

--- a/src/styling/base.scss
+++ b/src/styling/base.scss
@@ -43,16 +43,18 @@ html, body {
 .stage-title{
     position: absolute;
     top: 20vh;
-    h1{
-    color: $primary-colour;
-    font-size: 3rem;
-    }
-    p{
-        color: $primary-colour;
-    }
-    
+    margin: 0;
+    text-align: center;
 }
 
+.page-content{
+    position: absolute;
+    top: 20vh;
+    h1{
+    text-align: center;
+    margin: 0;
+    }
+}
 
 
 


### PR DESCRIPTION
Input Players Mobile Responsive Fix: Overlap of title and input field area
